### PR TITLE
fix on_serve missing **kwargs

### DIFF
--- a/mkpdfs_mkdocs/mkpdfs.py
+++ b/mkpdfs_mkdocs/mkpdfs.py
@@ -27,7 +27,7 @@ class Mkpdfs(BasePlugin):
     def __init__(self):
         self.generator = Generator()
 
-    def on_serve (self, server, config ):
+    def on_serve (self, server, config, **kwargs):
         # TODO: Implement watcher when the user is performing design
     #     print(server.watcher.__dict__)
     #     # builder = build(config, True, False)


### PR DESCRIPTION
Fixes error when using  `mkdocs serve`

```
TypeError: on_serve() got an unexpected keyword argument 'builder'
```

fixes #24 