### PR TITLE
Fix duplicate header id `doc-title`

### DIFF
--- a/mkpdfs_mkdocs/generator.py
+++ b/mkpdfs_mkdocs/generator.py
@@ -136,7 +136,7 @@ class Generator(object):
         start_dir), pdf_split[1])
 
     def add_tocs(self):
-        title = self.html.new_tag('h1', id='doc-title')
+        title = self.html.new_tag('h1', id='toc-title')
         title.insert(0, self.config['toc_title'])
         self._toc = self.html.new_tag('article', id='contents')
         self._toc.insert(0, title)


### PR DESCRIPTION
Just creating PR from interresting fixes from other forks so it can be merged to upstream.

> It was used by both the document's H1 and the TOC section H1 which
> resulted in the following warning:
> 
>    WARNING -  Anchor defined twice: doc-title
>
> TOC section H1 now has id `toc-title` instead of `doc-title`.