### PR TITLE
Fix link across multiple documents

### DIFF
--- a/mkpdfs_mkdocs/generator.py
+++ b/mkpdfs_mkdocs/generator.py
@@ -111,9 +111,6 @@ class Generator(object):
             self.generate = False
             return None
         article = prep_combined(article, base_url, page.file.url)
-        span = soup.new_tag('span')
-        span['id'] = 'mkpdf-{}'.format(url)
-        article.insert(0, span)
         if page.meta != None and 'pdf' in page.meta and page.meta['pdf'] == False:
             # print(page.meta)
             return self.get_path_to_pdf(page.file.dest_path)
@@ -204,8 +201,7 @@ class Generator(object):
         div = self.html.new_tag('div')
         menu = self.html.new_tag('div')
         h4 = self.html.new_tag('h4')
-        urlid = url.split('.')[0]
-        a = self.html.new_tag('a', href='#mkpdf-{}'.format(urlid))
+        a = self.html.new_tag('a', href='#')
         a.insert(0, p.title)
         h4.append(a)
         menu.append(h4)

--- a/mkpdfs_mkdocs/preprocessor/links/transform.py
+++ b/mkpdfs_mkdocs/preprocessor/links/transform.py
@@ -4,38 +4,15 @@ from .util import is_doc, normalize_href
 
 # normalize href to #foo/bar/section:id
 def transform_href(href: str, rel_url: str):
-    head, tail = os.path.split(href)
-
-    num_hashtags = tail.count('#')
-
-    if tail.startswith('#'):
-        head, section = os.path.split(rel_url)
-        section = os.path.splitext(section)[0]
-        id = tail[1:]
-    elif num_hashtags == 1:
-        section, ext = tuple(os.path.splitext(tail))
-        id = str.split(ext if len(ext) > 0 else section, '#')[1]
-
-        if head == '..':
-            href = normalize_href(href, rel_url)
-            return '#{}:{}'.format(href, id)
-
-    elif num_hashtags is 0:
-        if not is_doc(href):
-            return href
-
-        href = normalize_href(href, rel_url)
-        return '#{}:'.format(href)
-
-    if head != '':
-        head += '/'
-
-    return '#{}{}:{}'.format(head, section, id)
+    if not is_doc(href):
+        return href
+    if '#' not in href:
+        href += '#'
+    return "#" + normalize_href(href, rel_url).replace("#", ":", 1)
 
 # normalize id to foo/bar/section:id
 def transform_id(id: str, rel_url: str):
-    head, tail = os.path.split(rel_url)
-    section, _ = os.path.splitext(tail)
+    head, section = os.path.split(rel_url)
 
     if len(head) > 0:
         head += '/'

--- a/mkpdfs_mkdocs/preprocessor/links/util.py
+++ b/mkpdfs_mkdocs/preprocessor/links/util.py
@@ -3,20 +3,18 @@ import os
 from weasyprint import urls
 from bs4 import BeautifulSoup
 
+
 # check if href is relative --
 # if it is relative it *should* be an html that generates a PDF doc
 def is_doc(href: str):
-    tail = os.path.basename(href)
-    _, ext = os.path.splitext(tail)
-
-    absurl = urls.url_is_absolute(href)
-    abspath = os.path.isabs(href)
-    htmlfile = ext.startswith('.html')
-    if absurl or abspath or not htmlfile:
+    if urls.url_is_absolute(href):
         return False
-    
+    if os.path.isabs(href):
+        return False
+
     return True
-    
+
+
 def rel_pdf_href(href: str):
     head, tail = os.path.split(href)
     filename, _ = os.path.splitext(tail)
@@ -40,31 +38,40 @@ def replace_asset_hrefs(soup: BeautifulSoup, base_url: str):
 
     for asset in soup.find_all(src=True):
         asset['src'] = abs_asset_href(asset['src'], base_url)
-    
+
     return soup
 
-# normalize href to site root
+
 def normalize_href(href: str, rel_url: str):
-    # foo/bar/baz/../../index.html -> foo/index.html
-    def reduce_rel(x):
-        try:
-            i = x.index('..')
-            if i is 0:
-                return x
+    """
+    Normalize href to site root
+    foo/bar/baz/../../index.html -> foo/index.html
+    :param href:
+    :param rel_url:
+    :return:
 
-            del x[i]
-            del x[i - 1]
-            return reduce_rel(x)
-        except ValueError:
-            return x
+    >>> normalize_href("../../index.html", "foo/bar/baz/page.html")
+    'foo/index.html'
 
+    >>> normalize_href("page2.html#abcd", "foo/bar/baz/page.html")
+    'foo/bar/baz/page2.html#abcd'
+
+    >>> normalize_href("#section", "foo/bar/baz/page.html")
+    'foo/bar/baz/page.html#section'
+
+    >>> normalize_href("/index.html", "foo/bar/baz/page.html")
+    '/index.html'
+
+    >>> normalize_href("http://example.org/index.html", "foo/bar/baz/page.html")
+    'http://example.org/index.html'
+    """
+    if not is_doc(href):
+        return href
+    if href.startswith("#"):
+        return rel_url + href
     rel_dir = os.path.dirname(rel_url)
-    href = str.split(os.path.join(rel_dir, href), '/')
-    href = reduce_rel(href)
-    href[-1], _ = os.path.splitext(href[-1])
+    return os.path.normpath(os.path.join(rel_dir, href))
 
-    return os.path.join(*href)
 
 def get_body_id(url: str):
-    section, _ = os.path.splitext(url)
-    return '{}:'.format(section)
+    return '{}:'.format(url)


### PR DESCRIPTION
Generating links and appropriate ids was overcomplicated witch results in multiple unhandled edge cases.
File name extensions were removed, relative paths were not properly handled in all cases, etc. So it sometimes breaks linking between documents.

This PR just simplify all things and remove unnecesery URL manupulations.
It generates unique and consitant ids and hrefs.

It works well with both `use_directory_urls: False` and also `use_directory_urls: True`.

It generates same ids and hrefs in all cases, where original implementation works, and correct ids and hrefs in all other cases, where original implementation fails. One exception is just that with `use_directory_urls: False` urls and ids now also contains file name extensions, which just works. There is no need to remove them.

This also leads to not breaking external URLs.

