### PR TITLE
workaround a changed path in weasyprint submodule

### DIFF
--- a/mkpdfs_mkdocs/generator.py
+++ b/mkpdfs_mkdocs/generator.py
@@ -1,11 +1,15 @@
 import logging
 import os
 import sys
+import weasyprint
 from uuid import uuid4
 
 from weasyprint import HTML, urls, CSS
 from bs4 import BeautifulSoup
-from weasyprint.fonts import FontConfiguration
+if weasyprint.__version__ < '53':
+    from weasyprint.fonts import FontConfiguration
+else:
+    from weasyprint.text.fonts import FontConfiguration
 
 from mkpdfs_mkdocs.utils import gen_address
 from .utils import is_external


### PR DESCRIPTION
Fixes #51 

Alternative would be to pin the versions of weasyprint

setup.py
```
    install_requires=[
        'mkdocs>=0.17',
        'weasyprint>=0.44,<0.53',
        'beautifulsoup4>=4.6.3'
    ],
```

and maybe mention it in
README.md
```
3. WeasyPrint (Version >=0.44 to <0.53) depends on cairo, Pango and GDK-PixBuf which need to be installed separately. Please follow your platform installation instructions carefully:
    - [Linux][weasyprint-linux]
    - [MacOS][weasyprint-macos]
    - [Windows][weasyprint-windows]
```